### PR TITLE
feat: add file ignore and diff preview

### DIFF
--- a/controllers/admin/AdminCoreUpdaterController.php
+++ b/controllers/admin/AdminCoreUpdaterController.php
@@ -49,6 +49,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
     const ACTION_GET_DATABASE_DIFFERENCES = "GET_DATABASE_DIFFERENCES";
     const ACTION_APPLY_DATABASE_FIX = 'APPLY_DATABASE_FIX';
     const ACTION_RUN_POST_UPDATE_PROCESSES = 'RUN_POST_UPDATE_PROCESSES';
+    const ACTION_GET_FILE_DIFF = 'GET_FILE_DIFF';
 
     const SELECTED_PROCESS_MIGRATE_DB = 'SELECTED_PROCESS_MIGRATE_DB';
     const SELECTED_PROCESS_INITIALIZATION_CALLBACK = 'SELECTED_PROCESS_INITIALIZATION_CALLBACK';
@@ -777,6 +778,8 @@ class AdminCoreUpdaterController extends ModuleAdminController
                 return $this->getDatabaseDifferences();
             case static::ACTION_APPLY_DATABASE_FIX:
                 return $this->applyDatabaseFix(Tools::getValue('ids'));
+            case static::ACTION_GET_FILE_DIFF:
+                return $this->getFileDiff();
             default:
                 throw new PrestaShopException("Invalid action: $action");
         }
@@ -950,6 +953,14 @@ class AdminCoreUpdaterController extends ModuleAdminController
     protected function initUpdateProcess()
     {
         $compareProcessId = Tools::getValue('compareProcessId');
+        $ignored = Tools::getValue('ignore');
+        $ignoredFiles = [];
+        if ($ignored) {
+            $decoded = json_decode($ignored, true);
+            if (is_array($decoded)) {
+                $ignoredFiles = $decoded;
+            }
+        }
         $comparator = $this->factory->getComparator();
         $result = $comparator->getResult($compareProcessId);
         if (! $result) {
@@ -960,6 +971,16 @@ class AdminCoreUpdaterController extends ModuleAdminController
             $result['targetRevision'],
             $result['targetPHPVersion']
         );
+
+        if ($ignoredFiles) {
+            foreach ($ignoredFiles as $file) {
+                unset($result['changeSet']['change'][$file]);
+                unset($result['changeSet']['add'][$file]);
+                unset($result['changeSet']['remove'][$file]);
+                unset($targetFileList[$file]);
+            }
+        }
+
         $employeeId = (int)$this->context->employee->id;
         $updater = $this->factory->getUpdater();
         $processId = $updater->startProcess($employeeId, [
@@ -977,6 +998,90 @@ class AdminCoreUpdaterController extends ModuleAdminController
             'progress' => 0.0,
             'step' => $updater->describeCurrentStep($processId),
         ];
+    }
+
+    /**
+     * Returns diff between local and target version of file
+     *
+     * @return array
+     * @throws PrestaShopException
+     */
+    protected function getFileDiff()
+    {
+        $compareProcessId = Tools::getValue('compareProcessId');
+        $file = Tools::getValue('file');
+        $comparator = $this->factory->getComparator();
+        $result = $comparator->getResult($compareProcessId);
+        if (! $result) {
+            throw new PrestaShopException('Comparision result not found');
+        }
+
+        $changeSet = $result['changeSet'];
+        if (!(isset($changeSet['change'][$file]) || isset($changeSet['add'][$file]) || isset($changeSet['remove'][$file]))) {
+            throw new PrestaShopException('File not found in change set');
+        }
+
+        $localPath = _PS_ROOT_DIR_ . '/' . $file;
+        $local = @is_file($localPath) ? file_get_contents($localPath) : '';
+        $remote = '';
+        if (!isset($changeSet['remove'][$file])) {
+            $apiPath = preg_replace('#^' . preg_quote(_PS_ADMIN_DIR_ . '/', '#') . '#', 'admin/', $file);
+            $api = $this->factory->getApi();
+            $tmpArchive = tempnam(_PS_CACHE_DIR_, 'cu');
+            $api->downloadFiles($result['targetPHPVersion'], $result['targetRevision'], [$apiPath], $tmpArchive);
+            $tmpDir = tempnam(_PS_CACHE_DIR_, 'cu');
+            @unlink($tmpDir);
+            @mkdir($tmpDir, 0777, true);
+            $archive = new Archive_Tar($tmpArchive, 'gz');
+            $archive->extract($tmpDir);
+            @unlink($tmpArchive);
+            $remotePath = $tmpDir . '/' . $apiPath;
+            if (is_file($remotePath)) {
+                $remote = file_get_contents($remotePath);
+            }
+            Tools::deleteDirectory($tmpDir);
+        }
+
+        $diff = $this->generateDiff($local, $remote);
+
+        return [ 'diff' => $diff ];
+    }
+
+    /**
+     * Creates simple line based diff
+     *
+     * @param string $old
+     * @param string $new
+     * @return string
+     */
+    protected function generateDiff($old, $new)
+    {
+        if (function_exists('xdiff_string_diff')) {
+            $diff = xdiff_string_diff($old, $new, 1);
+            if ($diff !== false) {
+                return $diff;
+            }
+        }
+
+        $oldLines = explode("\n", $old);
+        $newLines = explode("\n", $new);
+        $max = max(count($oldLines), count($newLines));
+        $out = [];
+        for ($i = 0; $i < $max; $i++) {
+            $o = array_key_exists($i, $oldLines) ? $oldLines[$i] : null;
+            $n = array_key_exists($i, $newLines) ? $newLines[$i] : null;
+            if ($o === $n) {
+                $out[] = ' ' . $o;
+            } else {
+                if ($o !== null) {
+                    $out[] = '-' . $o;
+                }
+                if ($n !== null) {
+                    $out[] = '+' . $n;
+                }
+            }
+        }
+        return implode("\n", $out);
     }
 
     /**

--- a/views/css/coreupdater.css
+++ b/views/css/coreupdater.css
@@ -41,6 +41,27 @@
     font-size: 10px;
 }
 
+.file-list li .file-actions {
+    margin-left: 10px;
+}
+
+.file-list li .file-actions label {
+    margin-left: 10px;
+    font-weight: normal;
+}
+
+.diff-added {
+    color: #008000;
+}
+
+.diff-removed {
+    color: #b00000;
+}
+
+.diff-hunk {
+    color: #0000b0;
+}
+
 #db-changes .running,
 #db-changes .no-changes,
 #db-changes .db-error,

--- a/views/js/controller.js
+++ b/views/js/controller.js
@@ -176,10 +176,37 @@ window.initializeCoreUpdater = function(translations) {
 
   var update = function(compareProcessId) {
     initProgress(translations.UPDATE, translations.UPDATE_DESCRIPTION);
-    executeAction('INIT_UPDATE', { compareProcessId: compareProcessId })
+    var ignored = [];
+    $('.ignore-file:checked').each(function () {
+      ignored.push($(this).data('file'));
+    });
+    executeAction('INIT_UPDATE', { compareProcessId: compareProcessId, ignore: JSON.stringify(ignored) })
         .then(runUpdate)
         .catch(displayError);
   };
+
+  var showDiff = function(file, diff) {
+    var html = diff.split('\n').map(function(line) {
+      var cls = '';
+      if (line.indexOf('+') === 0) { cls = 'diff-added'; }
+      else if (line.indexOf('-') === 0) { cls = 'diff-removed'; }
+      else if (line.indexOf('@@') === 0) { cls = 'diff-hunk'; }
+      return '<div class="'+cls+'">'+$('<div>').text(line).html()+'</div>';
+    }).join('');
+    var $modal = $('#diff-modal');
+    $modal.find('.modal-title').text(file);
+    $modal.find('#diff-content').html(html);
+    $modal.modal('show');
+  };
+
+  $(document).on('click', '.preview-file', function(e) {
+    e.preventDefault();
+    var file = $(this).data('file');
+    var processId = $('#process-result').data('process-id');
+    executeAction('GET_FILE_DIFF', { file: file, compareProcessId: processId })
+      .then(function(result) { showDiff(file, result.diff); })
+      .catch(displayError);
+  });
 
   var checkDatabase = function() {
     document.getElementById('db-changes').className = 'status-running';

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -15,7 +15,7 @@
  * @copyright 2017-2024 thirty bees
  * @license   Academic Free License (AFL 3.0)
  *}
-<div class="panel" id="process-result">
+<div class="panel" id="process-result" data-process-id="{$compareProcessId}">
   <div class="panel-heading">
     {if !$edits && !$changes}
       {l s='Your system is updated' mod='coreupdater'}
@@ -115,6 +115,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <span class="file-actions">
+              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+              <label><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
+            </span>
           </li>
         {/foreach}
       </ul>
@@ -131,6 +135,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <span class="file-actions">
+              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+              <label><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
+            </span>
           </li>
         {/foreach}
       </ul>
@@ -147,6 +155,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <span class="file-actions">
+              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+              <label><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
+            </span>
           </li>
         {/foreach}
       </ul>
@@ -166,4 +178,18 @@
       });
     </script>
   {/if}
+</div>
+
+<div id="diff-modal" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' mod='coreupdater'}"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">{l s='Preview changes' mod='coreupdater'}</h4>
+      </div>
+      <div class="modal-body">
+        <pre id="diff-content" class="diff"></pre>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- allow admins to mark files to ignore during update
- provide file-level diff previews in update results
- style new actions and diff output

## Testing
- `php -l controllers/admin/AdminCoreUpdaterController.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae1d198ba0832d8aadfe7ec47f68e5