### PR TITLE
feat: allow ignoring files and previewing updates

### DIFF
--- a/controllers/admin/AdminCoreUpdaterController.php
+++ b/controllers/admin/AdminCoreUpdaterController.php
@@ -49,6 +49,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
     const ACTION_GET_DATABASE_DIFFERENCES = "GET_DATABASE_DIFFERENCES";
     const ACTION_APPLY_DATABASE_FIX = 'APPLY_DATABASE_FIX';
     const ACTION_RUN_POST_UPDATE_PROCESSES = 'RUN_POST_UPDATE_PROCESSES';
+    const ACTION_PREVIEW_FILE = 'PREVIEW_FILE';
 
     const SELECTED_PROCESS_MIGRATE_DB = 'SELECTED_PROCESS_MIGRATE_DB';
     const SELECTED_PROCESS_INITIALIZATION_CALLBACK = 'SELECTED_PROCESS_INITIALIZATION_CALLBACK';
@@ -777,6 +778,11 @@ class AdminCoreUpdaterController extends ModuleAdminController
                 return $this->getDatabaseDifferences();
             case static::ACTION_APPLY_DATABASE_FIX:
                 return $this->applyDatabaseFix(Tools::getValue('ids'));
+            case static::ACTION_PREVIEW_FILE:
+                return $this->previewFile(
+                    Tools::getValue('compareProcessId'),
+                    Tools::getValue('file')
+                );
             default:
                 throw new PrestaShopException("Invalid action: $action");
         }
@@ -945,6 +951,55 @@ class AdminCoreUpdaterController extends ModuleAdminController
     }
 
     /**
+     * Returns preview of file changes
+     *
+     * @param string $compareProcessId
+     * @param string $file
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     * @throws ThirtybeesApiException
+     */
+    protected function previewFile($compareProcessId, $file)
+    {
+        $comparator = $this->factory->getComparator();
+        $result = $comparator->getResult($compareProcessId);
+        if (! $result) {
+            throw new PrestaShopException('Comparision result not found.');
+        }
+
+        $remote = preg_replace('#^' . preg_quote(basename(_PS_ADMIN_DIR_)) . '/#', 'admin/', $file);
+
+        $tmpFile = tempnam(_PS_CACHE_DIR_, 'cu-');
+        $tmpDir = _PS_CACHE_DIR_ . 'coreupdater/preview/' . md5($file . microtime(true));
+        if (is_dir($tmpDir)) {
+            Tools::deleteDirectory($tmpDir);
+        }
+        mkdir($tmpDir, 0777, true);
+
+        $api = $this->factory->getApi();
+        $api->downloadFiles($result['targetPHPVersion'], $result['targetRevision'], [$remote], $tmpFile);
+
+        $archive = new Archive_Tar($tmpFile, true);
+        $archive->extract($tmpDir);
+
+        $remotePath = $tmpDir . '/' . $remote;
+        $remoteContent = file_exists($remotePath) ? file_get_contents($remotePath) : '';
+        $localPath = _PS_ROOT_DIR_ . '/' . $file;
+        $localContent = file_exists($localPath) ? file_get_contents($localPath) : '';
+
+        @unlink($tmpFile);
+        Tools::deleteDirectory($tmpDir);
+
+        return [
+            'file' => $file,
+            'local' => base64_encode($localContent),
+            'remote' => base64_encode($remoteContent),
+        ];
+    }
+
+    /**
      * @throws PrestaShopException
      */
     protected function initUpdateProcess()
@@ -954,6 +1009,15 @@ class AdminCoreUpdaterController extends ModuleAdminController
         $result = $comparator->getResult($compareProcessId);
         if (! $result) {
             throw new PrestaShopException("Comparision result not found. Please reload the page and try again");
+        }
+        $ignored = Tools::getValue('ignored');
+        if (!is_array($ignored)) {
+            $ignored = $ignored ? [ $ignored ] : [];
+        }
+        foreach ($ignored as $file) {
+            unset($result['changeSet']['change'][$file]);
+            unset($result['changeSet']['add'][$file]);
+            unset($result['changeSet']['remove'][$file]);
         }
         $targetFileList = $comparator->getFileList(
             $compareProcessId,

--- a/views/js/controller.js
+++ b/views/js/controller.js
@@ -174,10 +174,21 @@ window.initializeCoreUpdater = function(translations) {
     incrementProcess('UPDATE', process, endProgress);
   };
 
-  var update = function(compareProcessId) {
+  var update = function(compareProcessId, ignored) {
     initProgress(translations.UPDATE, translations.UPDATE_DESCRIPTION);
-    executeAction('INIT_UPDATE', { compareProcessId: compareProcessId })
+    executeAction('INIT_UPDATE', { compareProcessId: compareProcessId, ignored: ignored })
         .then(runUpdate)
+        .catch(displayError);
+  };
+
+  var preview = function(compareProcessId, file) {
+    executeAction('PREVIEW_FILE', { compareProcessId: compareProcessId, file: file })
+        .then(function(result) {
+          $('#previewModal .modal-title').text(result.file);
+          $('#preview-local').text(atob(result.local));
+          $('#preview-remote').text(atob(result.remote));
+          $('#previewModal').modal('show');
+        })
         .catch(displayError);
   };
 
@@ -282,6 +293,7 @@ window.initializeCoreUpdater = function(translations) {
     compare: compare,
     update: update,
     checkDatabase: checkDatabase,
+    preview: preview,
   }
 };
 

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -111,7 +111,11 @@
       <ul class="file-list">
         {foreach from=$changeSet['change'] key='file' item='modified'}
           <li>
-            <code>{$file|escape:'html'}</code>
+            <label>
+              <input type="checkbox" class="file-ignore" data-file="{$file|escape:'html'}"/>
+              <code>{$file|escape:'html'}</code>
+            </label>
+            <a href="#" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
@@ -127,7 +131,11 @@
       <ul class="file-list">
         {foreach from=$changeSet['add'] key='file' item='modified'}
           <li>
-            <code>{$file|escape:'html'}</code>
+            <label>
+              <input type="checkbox" class="file-ignore" data-file="{$file|escape:'html'}"/>
+              <code>{$file|escape:'html'}</code>
+            </label>
+            <a href="#" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
@@ -143,7 +151,10 @@
       <ul class="file-list">
         {foreach from=$changeSet['remove'] key='file' item='modified'}
           <li>
-            <code>{$file|escape:'html'}</code>
+            <label>
+              <input type="checkbox" class="file-ignore" data-file="{$file|escape:'html'}"/>
+              <code>{$file|escape:'html'}</code>
+            </label>
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
@@ -161,9 +172,42 @@
       </button>
     </div>
     <script type="application/javascript">
-      $("#update-button").click(function() {
-        coreUpdater.update("{$compareProcessId}");
+      $(function() {
+        $("#update-button").click(function() {
+          var ignored = [];
+          $(".file-ignore:checked").each(function() {
+            ignored.push($(this).data('file'));
+          });
+          coreUpdater.update("{$compareProcessId}", ignored);
+        });
+        $(".preview-file").click(function(e) {
+          e.preventDefault();
+          coreUpdater.preview("{$compareProcessId}", $(this).data('file'));
+        });
       });
     </script>
   {/if}
+</div>
+
+<div class="modal fade" id="previewModal" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">{l s='File preview' mod='coreupdater'}</h4>
+      </div>
+      <div class="modal-body">
+        <div class="row">
+          <div class="col-sm-6">
+            <h5>{l s='Current file' mod='coreupdater'}</h5>
+            <pre id="preview-local"></pre>
+          </div>
+          <div class="col-sm-6">
+            <h5>{l s='New file' mod='coreupdater'}</h5>
+            <pre id="preview-remote"></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- allow ignoring individual files during update
- add modal with side-by-side file preview
- support backend API for previewing files

## Testing
- `php -l controllers/admin/AdminCoreUpdaterController.php`
- `node --check views/js/controller.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae1d198ba0832d8aadfe7ec47f68e5