### PR TITLE
feat: add ignore and preview options

### DIFF
--- a/controllers/admin/AdminCoreUpdaterController.php
+++ b/controllers/admin/AdminCoreUpdaterController.php
@@ -46,6 +46,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
     const ACTION_COMPARE_PROCESS = "COMPARE";
     const ACTION_INIT_UPDATE = "INIT_UPDATE";
     const ACTION_UPDATE_PROCESS = "UPDATE";
+    const ACTION_GET_FILE_DIFF = "GET_FILE_DIFF";
     const ACTION_GET_DATABASE_DIFFERENCES = "GET_DATABASE_DIFFERENCES";
     const ACTION_APPLY_DATABASE_FIX = 'APPLY_DATABASE_FIX';
     const ACTION_RUN_POST_UPDATE_PROCESSES = 'RUN_POST_UPDATE_PROCESSES';
@@ -773,6 +774,8 @@ class AdminCoreUpdaterController extends ModuleAdminController
                 return $this->initUpdateProcess();
             case static::ACTION_UPDATE_PROCESS:
                 return $this->updateProcess(Tools::getValue('processId'));
+            case static::ACTION_GET_FILE_DIFF:
+                return $this->getFileDiff();
             case static::ACTION_GET_DATABASE_DIFFERENCES:
                 return $this->getDatabaseDifferences();
             case static::ACTION_APPLY_DATABASE_FIX:
@@ -955,6 +958,17 @@ class AdminCoreUpdaterController extends ModuleAdminController
         if (! $result) {
             throw new PrestaShopException("Comparision result not found. Please reload the page and try again");
         }
+        $ignored = Tools::getValue('ignored');
+        if ($ignored && !is_array($ignored)) {
+            $ignored = [ $ignored ];
+        }
+        if (is_array($ignored)) {
+            foreach ($ignored as $file) {
+                unset($result['changeSet']['change'][$file]);
+                unset($result['changeSet']['add'][$file]);
+                unset($result['changeSet']['remove'][$file]);
+            }
+        }
         $targetFileList = $comparator->getFileList(
             $compareProcessId,
             $result['targetRevision'],
@@ -977,6 +991,50 @@ class AdminCoreUpdaterController extends ModuleAdminController
             'progress' => 0.0,
             'step' => $updater->describeCurrentStep($processId),
         ];
+    }
+
+    /**
+     * Returns unified diff between local file and target file
+     *
+     * @return string
+     * @throws PrestaShopException
+     * @throws ThirtybeesApiException
+     */
+    protected function getFileDiff()
+    {
+        $file = Tools::getValue('file');
+        $compareProcessId = Tools::getValue('compareProcessId');
+        if (!$file || !$compareProcessId) {
+            throw new PrestaShopException('Missing parameters');
+        }
+        $comparator = $this->factory->getComparator();
+        $result = $comparator->getResult($compareProcessId);
+        if (!$result) {
+            throw new PrestaShopException('Comparision result not found. Please reload the page and try again');
+        }
+        $php = $result['targetPHPVersion'];
+        $revision = $result['targetRevision'];
+        $api = $this->factory->getApi();
+        $tmpArchive = tempnam(_PS_CACHE_DIR_, 'cu');
+        $remotePath = preg_replace('#^' . preg_quote(_PS_ADMIN_DIR_, '#') . '/#', 'admin/', $file);
+        $api->downloadFiles($php, $revision, [ $remotePath ], $tmpArchive);
+        $tmpDir = _PS_CACHE_DIR_ . 'cu_diff_' . uniqid();
+        $archive = new Archive_Tar($tmpArchive, 'gz');
+        $archive->extract($tmpDir);
+        @unlink($tmpArchive);
+        $remoteFile = $tmpDir . '/' . $remotePath;
+        $remoteContent = file_exists($remoteFile) ? file_get_contents($remoteFile) : '';
+        $localPath = _PS_ROOT_DIR_ . '/' . $file;
+        $localContent = file_exists($localPath) ? file_get_contents($localPath) : '';
+        $old = tempnam($tmpDir, 'old');
+        $new = tempnam($tmpDir, 'new');
+        file_put_contents($old, $localContent);
+        file_put_contents($new, $remoteContent);
+        $diff = shell_exec('diff -u ' . escapeshellarg($old) . ' ' . escapeshellarg($new));
+        @unlink($old);
+        @unlink($new);
+        Tools::deleteDirectory($tmpDir);
+        return $diff ? $diff : '';
     }
 
     /**

--- a/views/js/controller.js
+++ b/views/js/controller.js
@@ -174,11 +174,24 @@ window.initializeCoreUpdater = function(translations) {
     incrementProcess('UPDATE', process, endProgress);
   };
 
-  var update = function(compareProcessId) {
+  var update = function(compareProcessId, ignored) {
     initProgress(translations.UPDATE, translations.UPDATE_DESCRIPTION);
-    executeAction('INIT_UPDATE', { compareProcessId: compareProcessId })
+    var params = { compareProcessId: compareProcessId };
+    if (ignored && ignored.length > 0) {
+      params['ignored'] = ignored;
+    }
+    executeAction('INIT_UPDATE', params)
         .then(runUpdate)
         .catch(displayError);
+  };
+
+  var preview = function(compareProcessId, file) {
+    executeAction('GET_FILE_DIFF', { compareProcessId: compareProcessId, file: file })
+      .then(function(diff) {
+        $('#file-diff-content').text(diff);
+        $('#file-diff-modal').modal('show');
+      })
+      .catch(displayError);
   };
 
   var checkDatabase = function() {
@@ -282,6 +295,7 @@ window.initializeCoreUpdater = function(translations) {
     compare: compare,
     update: update,
     checkDatabase: checkDatabase,
+    preview: preview,
   }
 };
 

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -115,6 +115,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <label class="checkbox-inline">
+              <input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}" /> {l s='Ignore' mod='coreupdater'}
+            </label>
+            <button type="button" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</button>
           </li>
         {/foreach}
       </ul>
@@ -131,6 +135,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <label class="checkbox-inline">
+              <input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}" /> {l s='Ignore' mod='coreupdater'}
+            </label>
+            <button type="button" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</button>
           </li>
         {/foreach}
       </ul>
@@ -147,6 +155,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <label class="checkbox-inline">
+              <input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}" /> {l s='Ignore' mod='coreupdater'}
+            </label>
+            <button type="button" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</button>
           </li>
         {/foreach}
       </ul>
@@ -162,8 +174,30 @@
     </div>
     <script type="application/javascript">
       $("#update-button").click(function() {
-        coreUpdater.update("{$compareProcessId}");
+        var ignored = [];
+        $(".ignore-file:checked").each(function() {
+          ignored.push($(this).data('file'));
+        });
+        coreUpdater.update("{$compareProcessId}", ignored);
+      });
+      $(".preview-file").click(function() {
+        coreUpdater.preview("{$compareProcessId}", $(this).data('file'));
       });
     </script>
   {/if}
+
+  <div class="modal fade" id="file-diff-modal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' mod='coreupdater'}"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">{l s='File differences' mod='coreupdater'}</h4>
+        </div>
+        <div class="modal-body">
+          <pre id="file-diff-content"></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </div>


### PR DESCRIPTION
## Summary
- allow admins to skip selected files during core update
- preview remote/local file differences in a modal

## Testing
- `php -l controllers/admin/AdminCoreUpdaterController.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae1d198ba0832d8aadfe7ec47f68e5